### PR TITLE
fetch cpantesters data from the primary api domain

### DIFF
--- a/bin/cpan_testers_api.pl
+++ b/bin/cpan_testers_api.pl
@@ -18,7 +18,7 @@ my $home = home();
 my $url
     = $ENV{HARNESS_ACTIVE}
     ? 'file:' . $home->child('t/var/cpantesters-release-api-fake.json')
-    : 'http://api-3.cpantesters.org/v3/release';
+    : 'http://api.cpantesters.org/v3/release';
 
 my $ua = ua();
 


### PR DESCRIPTION
The server at api-3.cpantesters.org died, and the alias was once a way to get around Fastly for looking at this data. It seems like using Fastly works fine now, so we can switch to the primary API domain.